### PR TITLE
Workaround build -v ./... failing with 1 for go1.3

### DIFF
--- a/test/accept.go
+++ b/test/accept.go
@@ -1,0 +1,1 @@
+package accept_test


### PR DESCRIPTION
From Pulse:

6/26/14 2:07:28 PM CEST: go build github.com/x-formation/pulsekit/test: no
buildable Go source files in /ramdisk/pulsedata/work/src/github.com/x-formation/pulsekit/test

Command 'go build' completed with status failure
